### PR TITLE
Add basic GOST CMS support

### DIFF
--- a/src/ksba.h.in
+++ b/src/ksba.h.in
@@ -378,6 +378,10 @@ void ksba_cms_set_hash_function (ksba_cms_t cms,
                                  void *hash_fnc_arg);
 
 gpg_error_t ksba_cms_hash_signed_attrs (ksba_cms_t cms, int idx);
+gpg_error_t ksba_cms_check_signed_attrs_gost (ksba_cms_t cms, int idx,
+                                              const char *content_oid,
+                                              const unsigned char *digest,
+                                              size_t digest_len);
 
 
 gpg_error_t ksba_cms_set_content_type (ksba_cms_t cms, int what,

--- a/src/libksba.def
+++ b/src/libksba.def
@@ -208,3 +208,4 @@ EXPORTS
       ksba_der_add_end                @162
       ksba_der_builder_get            @163
       ksba_check_cert_sig             @164
+      ksba_cms_check_signed_attrs_gost @165

--- a/src/visibility.h
+++ b/src/visibility.h
@@ -105,6 +105,7 @@
 #define ksba_cms_get_sigattr_oids          _ksba_cms_get_sigattr_oids
 #define ksba_cms_get_signing_time          _ksba_cms_get_signing_time
 #define ksba_cms_hash_signed_attrs         _ksba_cms_hash_signed_attrs
+#define ksba_cms_check_signed_attrs_gost   _ksba_cms_check_signed_attrs_gost
 #define ksba_cms_identify                  _ksba_cms_identify
 #define ksba_cms_new                       _ksba_cms_new
 #define ksba_cms_parse                     _ksba_cms_parse
@@ -313,6 +314,7 @@ int ksba_asn_delete_structure (void *dummy);
 #undef ksba_cms_get_sigattr_oids
 #undef ksba_cms_get_signing_time
 #undef ksba_cms_hash_signed_attrs
+#undef ksba_cms_check_signed_attrs_gost
 #undef ksba_cms_identify
 #undef ksba_cms_new
 #undef ksba_cms_parse
@@ -490,6 +492,7 @@ MARK_VISIBLE (ksba_cms_get_sig_val)
 MARK_VISIBLE (ksba_cms_get_sigattr_oids)
 MARK_VISIBLE (ksba_cms_get_signing_time)
 MARK_VISIBLE (ksba_cms_hash_signed_attrs)
+MARK_VISIBLE (ksba_cms_check_signed_attrs_gost)
 MARK_VISIBLE (ksba_cms_identify)
 MARK_VISIBLE (ksba_cms_new)
 MARK_VISIBLE (ksba_cms_parse)


### PR DESCRIPTION
## Summary
- add byte inversion helper in `cms.c`
- allow GOST algorithms in `ksba_cms_set_sig_val`
- encode GOST signatures as reversed `s||r`
- new API `ksba_cms_check_signed_attrs_gost`
- export the new symbol

## Testing
- `./autogen.sh --force`
- `./configure --enable-maintainer-mode`
- `make -j$(nproc)`
- `make -j$(nproc) check`

------
https://chatgpt.com/codex/tasks/task_e_685998789ab0832e842954d9e5e13b90